### PR TITLE
Fix NPE on BluetoothAdapter being null on Emulators

### DIFF
--- a/myonnaise/src/main/java/com/ncorti/myonnaise/Myonnaise.kt
+++ b/myonnaise/src/main/java/com/ncorti/myonnaise/Myonnaise.kt
@@ -26,7 +26,7 @@ class Myonnaise(val context: Context) {
 
     private val blManager = context.getSystemService(Activity.BLUETOOTH_SERVICE) as BluetoothManager
     private val blAdapter = blManager.adapter
-    private val blLowEnergyScanner = blAdapter.bluetoothLeScanner
+    private val blLowEnergyScanner = blAdapter?.bluetoothLeScanner
 
     private var scanCallback: MyonnaiseScanCallback? = null
 
@@ -51,10 +51,10 @@ class Myonnaise(val context: Context) {
     fun startScan(): Flowable<BluetoothDevice> {
         val scanFlowable: Flowable<BluetoothDevice> = Flowable.create({
             scanCallback = MyonnaiseScanCallback(it)
-            blLowEnergyScanner.startScan(scanCallback)
+            blLowEnergyScanner?.startScan(scanCallback)
         }, BackpressureStrategy.BUFFER)
         return scanFlowable.doOnCancel {
-            blLowEnergyScanner.stopScan(scanCallback)
+            blLowEnergyScanner?.stopScan(scanCallback)
         }
     }
 
@@ -99,7 +99,7 @@ class Myonnaise(val context: Context) {
             val settings = ScanSettings.Builder()
                     .setScanMode(ScanSettings.SCAN_MODE_LOW_POWER)
                     .build()
-            blLowEnergyScanner.startScan(listOf(filter), settings, object : ScanCallback() {
+            blLowEnergyScanner?.startScan(listOf(filter), settings, object : ScanCallback() {
                 override fun onScanResult(callbackType: Int, result: ScanResult?) {
                     super.onScanResult(callbackType, result)
                     result?.device?.apply {


### PR DESCRIPTION
The sample app can't work on a Emulator given that [the Android emulator has no Bluetooth](https://stackoverflow.com/questions/6275863/how-to-simulate-bluetooth-on-android-emulator/7938959).

Currently the sample app is crashing at startup. I'm updating it to do not crash and fail the scan.